### PR TITLE
inhibit read-only-mode in tshell mode

### DIFF
--- a/tshell.el
+++ b/tshell.el
@@ -82,6 +82,7 @@ Turning on Text mode runs the normal hook `text-mode-hook'."
   (setq-local tshell-mode t)
   (setq-local font-lock-defaults '(tshell-font-lock-keywords))
   (setq-local * nil)
+  (setq-local inhibit-read-only t)
   (setq header-line-format '(:eval (format "%s %s"
                                            (propertize
                                             (directory-file-name (abbreviate-file-name default-directory))


### PR DESCRIPTION
While the buffer might not be read-only, the text is. As a result,
functions that modify the tshell buffer fail with the following
message:

```
if: Buffer is read-only: #<buffer *tshell*>
```

By setting this variable to `t` within the mode, the text can still be modified.

Now when I run the following, the result is evaluated:

``` emacs-lisp
> (+ 1 2)
```